### PR TITLE
Load API_KEY from django settings.py file as an alternative

### DIFF
--- a/movieman2/__init__.py
+++ b/movieman2/__init__.py
@@ -1,4 +1,5 @@
 import os
 import tmdbsimple
+from django.conf import settings
 
-tmdbsimple.API_KEY = os.environ['MM2_TMDB_API_KEY']
+tmdbsimple.API_KEY = os.environ['MM2_TMDB_API_KEY'] or settings.MM2_TMDB_API_KEY


### PR DESCRIPTION
Sorry about creating a mess of another pull request a while back, I've created a new clean slate repository that **should** work.

**NOTE:** _that the MM2_API_KEY will not be exported on a Travis CI Build, this one will fail I believe._
Edit: Closes #9 
