### PR TITLE
Correctly load key from environment

### DIFF
--- a/movieman2/__init__.py
+++ b/movieman2/__init__.py
@@ -2,4 +2,4 @@ import os
 import tmdbsimple
 from django.conf import settings
 
-tmdbsimple.API_KEY = os.environ['MM2_TMDB_API_KEY'] or settings.MM2_TMDB_API_KEY
+tmdbsimple.API_KEY = os.environ.get('MM2_TMDB_API_KEY') or settings.MM2_TMDB_API_KEY


### PR DESCRIPTION
This closes an issue of if a key was not exported in an environment
it would raise a KeyError exception, the method now used resolves that
issue as it returns None instead of an error if the key does not exist,
allowing it to revert to the key set in the settings.
